### PR TITLE
공연을 등록한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mapstruct:mapstruct:1.5.1.Final'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceAdapter.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceAdapter.java
@@ -1,0 +1,37 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import com.jummi.ticket.performance.application.port.out.SavePerformancePort;
+import com.jummi.ticket.performance.converter.PerformanceMapper;
+import com.jummi.ticket.performance.domain.Performance;
+import com.jummi.ticket.performance.domain.Series;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+class PerformanceAdapter implements SavePerformancePort {
+    private final PerformanceMapper mapper;
+    private final PerformanceRepository performanceRepository;
+    private final SeriesRepository seriesRepository;
+
+    @Transactional
+    @Override
+    public Long savePerformance(Performance performance, List<Series> series) {
+        PerformanceEntity performanceEntity = mapper.convertDomainEntityToJpaEntity(performance);
+        PerformanceEntity saved = performanceRepository.save(performanceEntity);
+        Long performanceId = saved.getPerformanceId();
+
+        List<SeriesEntity> seriesEntities = series.stream()
+                .map(mapper::convertDomainEntityToJpaEntity)
+                .collect(Collectors.toList());
+        seriesEntities.forEach(seriesEntity -> seriesEntity.setPerformanceId(performanceId));
+        seriesRepository.saveAll(seriesEntities);
+
+        return performanceId;
+    }
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceEntity.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceEntity.java
@@ -1,0 +1,57 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import com.jummi.ticket.performance.domain.Genre;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "performance")
+@Entity
+public class PerformanceEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long performanceId;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Genre genre;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private String venue;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "series",
+            joinColumns = @JoinColumn(name = "performance_id")
+    )
+    private List<SeriesEntity> series = new ArrayList<>();
+
+    @ElementCollection
+    @Column(name = "casts")
+    private List<String> casts = new ArrayList<>();
+
+    private int runTime;
+
+    private int minAvailableAge;
+
+    @Enumerated(EnumType.STRING)
+    @ElementCollection
+    @CollectionTable(
+            name = "reservation_sites",
+            joinColumns = @JoinColumn(name = "performance_id")
+    )
+    private Set<ReservationSiteEntity> reservationSites = new HashSet<>();
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceRepository.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/PerformanceRepository.java
@@ -1,0 +1,6 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface PerformanceRepository extends JpaRepository<PerformanceEntity, Long> {
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/ReservationSiteEntity.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/ReservationSiteEntity.java
@@ -1,0 +1,8 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public enum ReservationSiteEntity {
+    INTERPARK, YES24, MELON
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/SeriesEntity.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/SeriesEntity.java
@@ -1,0 +1,20 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeriesEntity {
+    private Long seriesId;
+    @Setter
+    private Long performanceId;
+    private LocalDate playDate;
+    private LocalTime playTime;
+    private boolean isPerformed;
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/persistence/SeriesRepository.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/persistence/SeriesRepository.java
@@ -1,0 +1,6 @@
+package com.jummi.ticket.performance.adapter.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeriesRepository extends JpaRepository<SeriesEntity, Long> {
+}

--- a/src/main/java/com/jummi/ticket/performance/adapter/web/RegisterPerformanceController.java
+++ b/src/main/java/com/jummi/ticket/performance/adapter/web/RegisterPerformanceController.java
@@ -1,0 +1,30 @@
+package com.jummi.ticket.performance.adapter.web;
+
+import com.jummi.ticket.performance.application.port.in.RegisterPerformanceCommand;
+import com.jummi.ticket.performance.application.port.in.RegisterPerformanceRequest;
+import com.jummi.ticket.performance.domain.PerformanceId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/performances")
+@RestController
+class RegisterPerformanceController {
+    private final RegisterPerformanceCommand registerPerformanceCommand;
+
+    @PostMapping
+    ResponseEntity<Void> registerPerformance(@RequestBody @Valid RegisterPerformanceRequest request) {
+        PerformanceId performanceId = registerPerformanceCommand.registerPerformance(request);
+
+        return ResponseEntity.created(
+                        URI.create("/api/performances/" + performanceId.id()))
+                .build();
+    }
+}

--- a/src/main/java/com/jummi/ticket/performance/application/port/in/RegisterPerformanceCommand.java
+++ b/src/main/java/com/jummi/ticket/performance/application/port/in/RegisterPerformanceCommand.java
@@ -1,0 +1,7 @@
+package com.jummi.ticket.performance.application.port.in;
+
+import com.jummi.ticket.performance.domain.PerformanceId;
+
+public interface RegisterPerformanceCommand {
+    PerformanceId registerPerformance(RegisterPerformanceRequest request);
+}

--- a/src/main/java/com/jummi/ticket/performance/application/port/in/RegisterPerformanceRequest.java
+++ b/src/main/java/com/jummi/ticket/performance/application/port/in/RegisterPerformanceRequest.java
@@ -1,0 +1,49 @@
+package com.jummi.ticket.performance.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@RequiredArgsConstructor
+@Getter
+public class RegisterPerformanceRequest {
+    @NotBlank
+    private final String title;
+
+    @NotBlank
+    private final String genre;
+
+    @NotBlank
+    @DateTimeFormat(pattern = "yyyyMMdd")
+    private final LocalDate startDate;
+
+    @NotBlank
+    @DateTimeFormat(pattern = "yyyyMMdd")
+    private final LocalDate endDate;
+
+    @NotBlank
+    private final String venue;
+
+    @NotNull
+    private final List<SeriesRequest> series;
+
+    @NotBlank
+    private final List<String> casts;
+
+    @Positive
+    private final int runTime;
+
+    @Positive
+    private final int minAvailableAge;
+
+    @NotNull
+    private final List<String> reservationSites;
+}

--- a/src/main/java/com/jummi/ticket/performance/application/port/in/SeriesRequest.java
+++ b/src/main/java/com/jummi/ticket/performance/application/port/in/SeriesRequest.java
@@ -1,0 +1,20 @@
+package com.jummi.ticket.performance.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Builder
+@RequiredArgsConstructor
+@Getter
+public class SeriesRequest {
+    @NotNull
+    @DateTimeFormat(pattern = "yyyyMMddHHmm")
+    private final LocalDateTime dateTime;
+
+    private final boolean isPerformed;
+}

--- a/src/main/java/com/jummi/ticket/performance/application/port/out/SavePerformancePort.java
+++ b/src/main/java/com/jummi/ticket/performance/application/port/out/SavePerformancePort.java
@@ -1,0 +1,10 @@
+package com.jummi.ticket.performance.application.port.out;
+
+import com.jummi.ticket.performance.domain.Performance;
+import com.jummi.ticket.performance.domain.Series;
+
+import java.util.List;
+
+public interface SavePerformancePort {
+    Long savePerformance(Performance performance, List<Series> series);
+}

--- a/src/main/java/com/jummi/ticket/performance/application/service/RegisterPerformanceService.java
+++ b/src/main/java/com/jummi/ticket/performance/application/service/RegisterPerformanceService.java
@@ -1,0 +1,29 @@
+package com.jummi.ticket.performance.application.service;
+
+import com.jummi.ticket.performance.application.port.in.RegisterPerformanceCommand;
+import com.jummi.ticket.performance.application.port.in.RegisterPerformanceRequest;
+import com.jummi.ticket.performance.application.port.out.SavePerformancePort;
+import com.jummi.ticket.performance.converter.PerformanceMapper;
+import com.jummi.ticket.performance.domain.Performance;
+import com.jummi.ticket.performance.domain.PerformanceId;
+import com.jummi.ticket.performance.domain.Series;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class RegisterPerformanceService implements RegisterPerformanceCommand {
+    private final PerformanceMapper mapper;
+    private final SavePerformancePort savePerformancePort;
+
+    @Override
+    public PerformanceId registerPerformance(RegisterPerformanceRequest request) {
+        Performance performance = mapper.convertRequestToDomainEntity(request);
+        List<Series> series = mapper.extractSeriesDomainEntity(request);
+        Long performanceId = savePerformancePort.savePerformance(performance, series);
+
+        return new PerformanceId(performanceId);
+    }
+}

--- a/src/main/java/com/jummi/ticket/performance/converter/PerformanceMapper.java
+++ b/src/main/java/com/jummi/ticket/performance/converter/PerformanceMapper.java
@@ -1,0 +1,52 @@
+package com.jummi.ticket.performance.converter;
+
+import com.jummi.ticket.performance.application.port.in.RegisterPerformanceRequest;
+import com.jummi.ticket.performance.application.port.in.SeriesRequest;
+import com.jummi.ticket.performance.domain.*;
+import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Mapper
+public interface PerformanceMapper {
+    default Performance convertRequestToDomainEntity(RegisterPerformanceRequest request) {
+        return Performance.builder()
+                .title(request.getTitle())
+                .genre(Genre.valueOf(request.getGenre()))
+                .period(new Period(request.getStartDate(), request.getEndDate()))
+                .venue(request.getVenue())
+                .casts(request.getCasts())
+                .runTime(request.getRunTime())
+                .minAvailableAge(request.getMinAvailableAge())
+                .reservationSites(convertStringToEnum(request.getReservationSites()))
+                .build();
+    }
+
+    default List<ReservationSite> convertStringToEnum(List<String> reservationSites) {
+        return reservationSites.stream()
+                .map(ReservationSite::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    default List<Series> extractSeriesDomainEntity(RegisterPerformanceRequest request) {
+        return request.getSeries()
+                .stream()
+                .map(this::convertRequestToDomainEntity)
+                .collect(Collectors.toList());
+    }
+
+    default Series convertRequestToDomainEntity(SeriesRequest seriesRequest) {
+        LocalDate date = seriesRequest.getDateTime().toLocalDate();
+        LocalTime time = seriesRequest.getDateTime().toLocalTime();
+        return Series.builder()
+                .playDate(date)
+                .playTime(time)
+                .isPerformed(seriesRequest.isPerformed())
+                .build();
+    }
+}

--- a/src/main/java/com/jummi/ticket/performance/converter/PerformanceMapper.java
+++ b/src/main/java/com/jummi/ticket/performance/converter/PerformanceMapper.java
@@ -1,5 +1,7 @@
 package com.jummi.ticket.performance.converter;
 
+import com.jummi.ticket.performance.adapter.persistence.PerformanceEntity;
+import com.jummi.ticket.performance.adapter.persistence.SeriesEntity;
 import com.jummi.ticket.performance.application.port.in.RegisterPerformanceRequest;
 import com.jummi.ticket.performance.application.port.in.SeriesRequest;
 import com.jummi.ticket.performance.domain.*;
@@ -14,6 +16,8 @@ import java.util.stream.Collectors;
 @Component
 @Mapper
 public interface PerformanceMapper {
+    PerformanceEntity convertDomainEntityToJpaEntity(Performance performance);
+
     default Performance convertRequestToDomainEntity(RegisterPerformanceRequest request) {
         return Performance.builder()
                 .title(request.getTitle())
@@ -32,6 +36,8 @@ public interface PerformanceMapper {
                 .map(ReservationSite::valueOf)
                 .collect(Collectors.toList());
     }
+
+    SeriesEntity convertDomainEntityToJpaEntity(Series series);
 
     default List<Series> extractSeriesDomainEntity(RegisterPerformanceRequest request) {
         return request.getSeries()

--- a/src/main/java/com/jummi/ticket/performance/domain/Genre.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/Genre.java
@@ -1,0 +1,5 @@
+package com.jummi.ticket.performance.domain;
+
+public enum Genre {
+    CONCERT, MUSICAL, PLAY, CLASSICAL, OPERA, DANCE, TRADITIONAL, SPORTS, EXHIBITIONS, LEISURE
+}

--- a/src/main/java/com/jummi/ticket/performance/domain/Performance.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/Performance.java
@@ -1,0 +1,22 @@
+package com.jummi.ticket.performance.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Performance {
+    private PerformanceId performanceId;
+    private String title;
+    private Genre genre;
+    private Period period;
+    private String venue;
+    private List<Series> series;
+    private List<String> casts;
+    private int runTime;
+    private int minAvailableAge;
+    private List<ReservationSite> reservationSites;
+}

--- a/src/main/java/com/jummi/ticket/performance/domain/PerformanceId.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/PerformanceId.java
@@ -1,0 +1,4 @@
+package com.jummi.ticket.performance.domain;
+
+public record PerformanceId(Long id) {
+}

--- a/src/main/java/com/jummi/ticket/performance/domain/Period.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/Period.java
@@ -1,0 +1,6 @@
+package com.jummi.ticket.performance.domain;
+
+import java.time.LocalDate;
+
+public record Period(LocalDate startDate, LocalDate endDate) {
+}

--- a/src/main/java/com/jummi/ticket/performance/domain/ReservationSite.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/ReservationSite.java
@@ -1,0 +1,5 @@
+package com.jummi.ticket.performance.domain;
+
+public enum ReservationSite {
+    INTERPARK, YES24, MELON
+}

--- a/src/main/java/com/jummi/ticket/performance/domain/Series.java
+++ b/src/main/java/com/jummi/ticket/performance/domain/Series.java
@@ -1,0 +1,12 @@
+package com.jummi.ticket.performance.domain;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record Series(Long seriesId, Long performanceId, LocalDate playDate, LocalTime playTime, boolean isPerformed) {
+    @Builder
+    public Series {
+    }
+}


### PR DESCRIPTION
1. application/port/out/의 영속성 아웃고잉 포트 클래스 이름이 고민입니다. application/port/in/의 웹 인커밍 포트들은 `~Command`나 `~Query`같이 클래스명을 썼지만, 아웃고잉 포트의 구체적 명칭을 `~Port`대신 특정 이름을 어떻게 지어야할지 고민이 되더라구요. 다른 분들은 이 부분 어떻게 하셨는지 궁금합니다!

2. Controller의 RequestBody로 들어오는 `RegisterPerformanceRequest` class를 다른 처리를 해줄필요가 없어서 서비스로 그대로 내려주어서 사용을 하였습니다. 컨트롤러와 서비스에서 이 `Request`를 둘 다 사용하게 되니까 애플리케이션의 입력이므로 adapter/web에 위치시킬지, 의존성 방향에 따라 application/port/in에 위치시킬지 고민이 됐습니다. 이 부분도 리뷰어분들이 어떻게 생각하시는지 궁금합니다

### 추가 작업
- BaseEntity 분리
- 예외 처리
- 엔티티 연관관계
- 테스트